### PR TITLE
Update Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module arnested.dk/go/healthy
 
-go 1.26.4
+go 1.26.5
 
 require github.com/docker/docker v28.5.2+incompatible
 


### PR DESCRIPTION
Update Go version to 1.26.5.

See [the release history](https://go.dev/doc/devel/release#go1.26.5).